### PR TITLE
Removed unnecessary copy task

### DIFF
--- a/ansible/roles/secondary-masters/tasks/main.yaml
+++ b/ansible/roles/secondary-masters/tasks/main.yaml
@@ -6,9 +6,6 @@
 - name: Make sure that kubelet is not up
   service: name=kubelet state=stopped
 
-- name: Copy /tmp/kubernetes-conf.tar.gz
-  copy: src=/tmp/kubernetes-conf.tar.gz dest=/tmp/kubernetes-conf.tar.gz
-
 - name: Extract /tmp/kubernetes-conf.tar.gz
   unarchive: src=/tmp/kubernetes-conf.tar.gz dest=/etc/
 


### PR DESCRIPTION
The default source of the following `unarchive` task is your host machine an not the remote machine. Therefore, it isn't necessary to copy the archive before.